### PR TITLE
Setting the 'video_resolution' attribute could be the solution for Andro...

### DIFF
--- a/Contents/Services/URL/filmon/ServiceCode.pys
+++ b/Contents/Services/URL/filmon/ServiceCode.pys
@@ -24,6 +24,7 @@ def MediaObjectsForURL(url):
 	return [
 		MediaObject(
 			audio_channels = 2,
+			video_resolution = 'sd',
 			optimized_for_streaming = True,
 			parts = [
 				PartObject(


### PR DESCRIPTION
...id. Android always wants a 'video_resolution', it doesn\'t really matter what the resolution returned in the HLS playlist is.
